### PR TITLE
Remove recordings at locations outside of cell

### DIFF
--- a/bluepyemodel/emodel_pipeline/emodel_pipeline.py
+++ b/bluepyemodel/emodel_pipeline/emodel_pipeline.py
@@ -60,7 +60,6 @@ class EModel_pipeline:
         recipes_path=None,
         use_ipyparallel=None,
         use_multiprocessing=None,
-        data_access_point=None,
     ):
         """Initializes the EModel_pipeline.
 
@@ -109,7 +108,7 @@ class EModel_pipeline:
                 of the e-model building pipeline be based on multiprocessing.
         """
 
-        # pylint: disable=too-many-arguments, unused-argument
+        # pylint: disable=too-many-arguments
 
         if use_ipyparallel and use_multiprocessing:
             raise ValueError(

--- a/bluepyemodel/emodel_pipeline/emodel_pipeline.py
+++ b/bluepyemodel/emodel_pipeline/emodel_pipeline.py
@@ -60,6 +60,7 @@ class EModel_pipeline:
         recipes_path=None,
         use_ipyparallel=None,
         use_multiprocessing=None,
+        data_access_point=None,
     ):
         """Initializes the EModel_pipeline.
 

--- a/bluepyemodel/emodel_pipeline/emodel_pipeline.py
+++ b/bluepyemodel/emodel_pipeline/emodel_pipeline.py
@@ -109,7 +109,7 @@ class EModel_pipeline:
                 of the e-model building pipeline be based on multiprocessing.
         """
 
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments, unused-argument
 
         if use_ipyparallel and use_multiprocessing:
             raise ValueError(

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -518,7 +518,7 @@ class FitnessCalculatorConfiguration:
                         except EPhysLocInstantiateException:
                             logger.warning(
                                 "Could not find %s, ignoring recording at this location",
-                                location.name
+                                location.name,
                             )
                             skipped_recordings.append(_rec["name"])
                 else:

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -19,6 +19,8 @@ limitations under the License.
 import logging
 from copy import deepcopy
 
+from bluepyopt.ephys.locations import EPhysLocInstantiateException
+
 from bluepyemodel.evaluation.efeature_configuration import EFeatureConfiguration
 from bluepyemodel.evaluation.evaluator import LEGACY_PRE_PROTOCOLS
 from bluepyemodel.evaluation.evaluator import PRE_PROTOCOLS
@@ -26,7 +28,6 @@ from bluepyemodel.evaluation.evaluator import define_location
 from bluepyemodel.evaluation.evaluator import seclist_to_sec
 from bluepyemodel.evaluation.protocol_configuration import ProtocolConfiguration
 from bluepyemodel.tools.utils import are_same_protocol
-from bluepyopt.ephys.locations import EPhysLocInstantiateException
 
 logger = logging.getLogger(__name__)
 
@@ -516,8 +517,8 @@ class FitnessCalculatorConfiguration:
                             recordings.append(_rec)
                         except EPhysLocInstantiateException:
                             logger.warning(
-                                f"Could not find {location.name}, "
-                                "ignoring recording at this location"
+                                "Could not find %s, ignoring recording at this location",
+                                location.name
                             )
                             skipped_recordings.append(_rec["name"])
                 else:
@@ -532,7 +533,7 @@ class FitnessCalculatorConfiguration:
                 for skiprec in skipped_recordings:
                     if f"{efeature.protocol_name}.{efeature.recording_name}" == skiprec:
                         to_remove.append(i)
-                        logger.warning(f"removing {efeature.name}")
+                        logger.warning("Removing %s", efeature.name)
                         continue
                 # if the loc of the recording is of the form axon*.v, we replace * by
                 # all the corresponding int from the created recordings

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -511,8 +511,7 @@ class FitnessCalculatorConfiguration:
                 if rec["type"] != "CompRecording":
                     for _rec in _set_morphology_dependent_locations(rec, cell):
                         try:
-                            tmp_rec = deepcopy(_rec)
-                            location = define_location(tmp_rec)
+                            location = define_location(_rec)
                             location.instantiate(sim=simulator, icell=cell.icell)
                             recordings.append(_rec)
                         except EPhysLocInstantiateException:

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -519,7 +519,7 @@ class FitnessCalculatorConfiguration:
                                 f"Could not find {location.name}, "
                                 "ignoring recording at this location"
                             )
-                            skipped_recordings.append((protocol.name, _rec.name))
+                            skipped_recordings.append(_rec["name"])
                 else:
                     recordings.append(self.protocols[i].recordings[j])
             self.protocols[i].recordings = recordings
@@ -530,8 +530,9 @@ class FitnessCalculatorConfiguration:
             if isinstance(efeature.recording_name, str):
                 # remove efeature associated to skipped recording
                 for skiprec in skipped_recordings:
-                    if efeature.protocol_name == skiprec[0] and efeature.recording_name == skiprec[1]:
+                    if f"{efeature.protocol_name}.{efeature.recording_name}" == skiprec:
                         to_remove.append(i)
+                        logger.warning(f"removing {efeature.name}")
                         continue
                 # if the loc of the recording is of the form axon*.v, we replace * by
                 # all the corresponding int from the created recordings

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -29,45 +29,45 @@ from bluepyemodel.tools.utils import are_same_protocol
 logger = logging.getLogger(__name__)
 
 
-def _set_morphology_dependent_locations(stimulus, cell):
+def _set_morphology_dependent_locations(recording, cell):
     """Here we deal with morphology dependent locations"""
 
-    def _get_stim(stimulus, sec_id):
-        new_stim = deepcopy(stimulus)
-        stim_split = stimulus["name"].split(".")
-        new_stim["type"] = "nrnseclistcomp"
-        new_stim["name"] = f"{'.'.join(stim_split[:-1])}_{sec_id}.{stim_split[-1]}"
-        new_stim["sec_index"] = sec_id
-        return new_stim
+    def _get_rec(recording, sec_id):
+        new_rec = deepcopy(recording)
+        rec_split = recording["name"].split(".")
+        new_rec["type"] = "nrnseclistcomp"
+        new_rec["name"] = f"{'.'.join(rec_split[:-1])}_{sec_id}.{rec_split[-1]}"
+        new_rec["sec_index"] = sec_id
+        return new_rec
 
-    new_stims = []
-    if stimulus["type"] == "somadistanceapic":
-        new_stims = [deepcopy(stimulus)]
-        new_stims[0]["sec_name"] = seclist_to_sec.get(
-            stimulus["seclist_name"], stimulus["seclist_name"]
+    new_recs = []
+    if recording["type"] == "somadistanceapic":
+        new_recs = [deepcopy(recording)]
+        new_recs[0]["sec_name"] = seclist_to_sec.get(
+            recording["seclist_name"], recording["seclist_name"]
         )
 
-    elif stimulus["type"] == "terminal_sections":
+    elif recording["type"] == "terminal_sections":
         # all terminal sections
-        for sec_id, section in enumerate(getattr(cell.icell, stimulus["seclist_name"])):
+        for sec_id, section in enumerate(getattr(cell.icell, recording["seclist_name"])):
             if len(section.subtree()) == 1:
-                new_stims.append(_get_stim(stimulus, sec_id))
+                new_recs.append(_get_rec(recording, sec_id))
 
-    elif stimulus["type"] == "all_sections":
+    elif recording["type"] == "all_sections":
         # all section of given type
-        for sec_id, section in enumerate(getattr(cell.icell, stimulus["seclist_name"])):
-            new_stims.append(_get_stim(stimulus, sec_id))
+        for sec_id, section in enumerate(getattr(cell.icell, recording["seclist_name"])):
+            new_recs.append(_get_rec(recording, sec_id))
 
     else:
-        new_stims = [deepcopy(stimulus)]
+        new_recs = [deepcopy(recording)]
 
-    if len(new_stims) == 0 and stimulus["type"] in [
+    if len(new_recs) == 0 and recording["type"] in [
         "somadistanceapic",
         "terminal_sections",
         "all_sections",
     ]:
-        logger.warning("We could not add a location for %s", stimulus)
-    return new_stims
+        logger.warning("We could not add a location for %s", recording)
+    return new_recs
 
 
 class FitnessCalculatorConfiguration:
@@ -506,6 +506,8 @@ class FitnessCalculatorConfiguration:
             for j, rec in enumerate(protocol.recordings):
                 if rec["type"] != "CompRecording":
                     for _rec in _set_morphology_dependent_locations(rec, cell):
+                        try:
+                            tmp_stim = 
                         recordings.append(_rec)
                 else:
                     recordings.append(self.protocols[i].recordings[j])

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from bluepyemodel.evaluation.efeature_configuration import EFeatureConfiguration
 from bluepyemodel.evaluation.evaluator import LEGACY_PRE_PROTOCOLS
 from bluepyemodel.evaluation.evaluator import PRE_PROTOCOLS
+from bluepyemodel.evaluation.evaluator import define_location
 from bluepyemodel.evaluation.evaluator import seclist_to_sec
 from bluepyemodel.evaluation.protocol_configuration import ProtocolConfiguration
 from bluepyemodel.tools.utils import are_same_protocol
@@ -510,11 +511,12 @@ class FitnessCalculatorConfiguration:
                     for _rec in _set_morphology_dependent_locations(rec, cell):
                         try:
                             tmp_rec = deepcopy(_rec)
-                            tmp_rec.location.instantiate()
+                            location = define_location(tmp_rec)
+                            location.instantiate(sim=simulator, icell=cell.icell)
                             recordings.append(_rec)
                         except EPhysLocInstantiateException:
                             logger.warning(
-                                f"Could not find {_rec.location.name}, "
+                                f"Could not find {location.name}, "
                                 "ignoring recording at this location"
                             )
                             skipped_recordings.append((protocol.name, _rec.name))


### PR DESCRIPTION
Remove recordings at locations outside of cell, and efeatures using these recordings.

This can be useful when we want to record stuff in the dendrite, and apply this protocol to different cells and we don't know a priori the length of the dendrite in all of the cells.

Also replace 'stimulus' by 'recording' in _set_morphology_dependent_locations for clarity.