### PR TITLE
Refactor path_extract_config

### DIFF
--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -443,7 +443,6 @@ class LocalAccessPoint(DataAccessPoint):
     def get_targets_configuration(self):
         """Get the configuration of the targets (targets and ephys files used)"""
 
-
         if self.emodel_dir:
             path_extract_config = self.emodel_dir / self.pipeline_settings.path_extract_config
         else:

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -443,7 +443,11 @@ class LocalAccessPoint(DataAccessPoint):
     def get_targets_configuration(self):
         """Get the configuration of the targets (targets and ephys files used)"""
 
-        path_extract_config = self.pipeline_settings.path_extract_config
+
+        if self.emodel_dir:
+            path_extract_config = self.emodel_dir / self.pipeline_settings.path_extract_config
+        else:
+            path_extract_config = self.pipeline_settings.path_extract_config
 
         with open(path_extract_config, "r") as f:
             config_dict = json.load(f)

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -350,7 +350,7 @@ class LocalAccessPoint(DataAccessPoint):
         mechanisms_directory = self.emodel_dir / "mechanisms"
 
         if mechanisms_directory.is_dir():
-            return mechanisms_directory
+            return mechanisms_directory.resolve()
 
         return None
 

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -75,7 +75,9 @@ class LocalAccessPoint(DataAccessPoint):
 
         Args:
             emodel (str): name of the emodel.
-            emodel_dir (str): path to the working directory. Default to ./run/iteration_tag if None
+            emodel_dir (str): path to the working directory.
+                Default to current working directory.
+                If iteration_tag is not None, it will be ./run/iteration_tag
             ttype (str): name of the t-type
             iteration_tag (str): iteration tag
             final_path (str): path to final.json which will contain the optimised models.
@@ -345,13 +347,10 @@ class LocalAccessPoint(DataAccessPoint):
     def get_mechanisms_directory(self):
         """Return the path to the directory containing the mechanisms for the current emodel"""
 
-        if self.emodel_dir:
-            mechanisms_directory = self.emodel_dir / "mechanisms"
-        else:
-            mechanisms_directory = Path("./") / "mechanisms"
+        mechanisms_directory = self.emodel_dir / "mechanisms"
 
         if mechanisms_directory.is_dir():
-            return mechanisms_directory.resolve()
+            return mechanisms_directory
 
         return None
 
@@ -383,10 +382,7 @@ class LocalAccessPoint(DataAccessPoint):
 
         names = []
 
-        if self.emodel_dir:
-            morph_dir = self.emodel_dir / "morphology"
-        else:
-            morph_dir = Path("./") / "morphology"
+        morph_dir = self.emodel_dir / "morphology"
 
         if not morph_dir.is_dir():
             return None
@@ -443,10 +439,7 @@ class LocalAccessPoint(DataAccessPoint):
     def get_targets_configuration(self):
         """Get the configuration of the targets (targets and ephys files used)"""
 
-        if self.emodel_dir:
-            path_extract_config = self.emodel_dir / self.pipeline_settings.path_extract_config
-        else:
-            path_extract_config = self.pipeline_settings.path_extract_config
+        path_extract_config = self.emodel_dir / self.pipeline_settings.path_extract_config
 
         with open(path_extract_config, "r") as f:
             config_dict = json.load(f)

--- a/bluepyemodel/emodel_pipeline/emodel_settings.py
+++ b/bluepyemodel/emodel_pipeline/emodel_settings.py
@@ -199,7 +199,9 @@ class EModelPipelineSettings:
             compile_mechanisms (bool): should the mod files be copied in the local
                 mechanisms_dir directory. Only used by the Luigi workflow.
             path_extract_config (str): specify the path to the .json file containing the targets
-                for the extraction process. Only used with local access point.
+                for the extraction process. Defaults to the current directory.
+                If an 'iteration_tag' is provided, the file will be located in
+                './run/iteration_tag'. This is only applicable with a local access point.
                 See example emodel_pipeline_local_python for more details.
             name_Rin_protocol (list or str): name and amplitude of the protocol from which the
                 input resistance should be selected from. The matching protocol should have


### PR DESCRIPTION
Retrieve the ExtractionTargetsConfiguration from the relevant ``run`` folder, if available, rather than from the root directory, which is subject to change.