### PR TITLE
Architecture detection for mechanisms and switch to .o file checking

### DIFF
--- a/bluepyemodel/tasks/emodel_creation/optimisation.py
+++ b/bluepyemodel/tasks/emodel_creation/optimisation.py
@@ -155,8 +155,21 @@ class CompileMechanisms(WorkflowTaskRequiringMechanisms):
         targets = []
         mechanisms_directory = self.access_point.get_mechanisms_directory()
 
+        architectures = ["x86_64", "i686", "powerpc", "umac"]
+
+        # Detect the first existing architecture
+        arch_dir = None
+        for arch in architectures:
+            dir_to_check = mechanisms_directory.parents[0] / arch
+            if dir_to_check.exists() and dir_to_check.is_dir():
+                arch_dir = dir_to_check
+                break
+
+        if arch_dir is None:
+            raise ValueError("No valid architecture directory found")
+
         for filepath in glob.glob(f"{str(mechanisms_directory)}/*.mod"):
-            compile_path = mechanisms_directory.parents[0] / "x86_64" / f"{Path(filepath).stem}.c"
+            compile_path = mechanisms_directory.parents[0] / arch_dir / f"{Path(filepath).stem}.o"
             targets.append(luigi.LocalTarget(compile_path))
 
         return targets


### PR DESCRIPTION
- Implement architecture-specific directory detection for mechanisms with support for: 'i686,' 'x86_64,' 'powerpc,' and  'umac.'
- Switch to .o file checking