### PR TITLE
remove tests module from distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include bluepyemodel/export_emodel/templates/cell_template_neurodamus.jinja2
+recursive-exclude tests *

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,6 @@ setup(
     },
     packages=find_packages(exclude=('tests',)),
     include_package_data=True,
-    package_data={"": ["data/*.npy"]},
     keywords=[
         'computational neuroscience',
         'simulation',


### PR DESCRIPTION
The problem is that tests are not removed from package, even with `packages=find_packages(exclude=('tests',))` in `setup.py`, because we have `include_package_data=True` in `setup.py`, and we use `setuptools_scm`. Using `MANIFEST.in` to remove tests from distribution fixes this.

Also remove `package_data`, since there are no longer any `.npy` data in `bluepyemodel/ecode/data/ folder`