### PR TITLE
allow latest jinja2 in dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
         "neuron>=8.0",
         "morph_tool>=2.8",
         "fasteners>=0.16",
-        "jinja2==3.0.3",
+        "jinja2>=3.0.3",
         "currentscape>=0.0.11"
     ],
     extras_require={


### PR DESCRIPTION
The issue locking us at a version <3.1 has been solved: https://github.com/BlueBrain/sphinx-bluebrain-theme/issues/51