### PR TITLE
Implement protocol renaming feature post-extraction

### DIFF
--- a/bluepyemodel/access_point/access_point.py
+++ b/bluepyemodel/access_point/access_point.py
@@ -55,7 +55,6 @@ class OptimisationState(Enum):
 
 
 class DataAccessPoint:
-
     """Abstract data access point class. This class is not meant to be used directly.
     Instead, it is used through the classes LocalAccessPoint and NexusAccessPoint.
     """

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -448,6 +448,7 @@ class LocalAccessPoint(DataAccessPoint):
             files=config_dict["files"],
             targets=config_dict["targets"],
             protocols_rheobase=config_dict["protocols_rheobase"],
+            protocols_mapping=config_dict["protocols_mapping"]
         )
 
         return configuration

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -279,7 +279,8 @@ class LocalAccessPoint(DataAccessPoint):
 
     def store_emodel(self, emodel):
         """Store an emodel obtained from BluePyOpt in the final.json. Note that if a model in the
-        final.json has the same key (emodel__iteration_tag__seed), it will be overwritten."""
+        final.json has the same key (emodel__iteration_tag__seed), it will be overwritten.
+        """
 
         with self.rw_lock_final.write_lock():
             with self.rw_lock_final_tmp.write_lock():
@@ -288,7 +289,8 @@ class LocalAccessPoint(DataAccessPoint):
 
                 if model_name in final:
                     logger.warning(
-                        "Entry %s was already in the final.json and will be overwritten", model_name
+                        "Entry %s was already in the final.json and will be overwritten",
+                        model_name,
                     )
 
                 pdf_dependencies = emodel.build_pdf_dependencies(int(emodel.seed))
@@ -448,7 +450,7 @@ class LocalAccessPoint(DataAccessPoint):
             files=config_dict["files"],
             targets=config_dict["targets"],
             protocols_rheobase=config_dict["protocols_rheobase"],
-            protocols_mapping=config_dict["protocols_mapping"]
+            protocols_mapping=config_dict["protocols_mapping"],
         )
 
         return configuration
@@ -498,7 +500,10 @@ class LocalAccessPoint(DataAccessPoint):
 
             if from_bpe:
                 configuration.init_from_bluepyefe(
-                    efeatures, protocols, {}, self.pipeline_settings.threshold_efeature_std
+                    efeatures,
+                    protocols,
+                    {},
+                    self.pipeline_settings.threshold_efeature_std,
                 )
             else:
                 configuration.init_from_legacy_dict(

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -52,7 +52,6 @@ seclist_to_sec = {
 
 
 class LocalAccessPoint(DataAccessPoint):
-
     """Access point to access configuration files and e-models when stored locally."""
 
     def __init__(

--- a/bluepyemodel/ecode/apwaveform.py
+++ b/bluepyemodel/ecode/apwaveform.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class APWaveform(IDrest):
-
     """APWaveform current stimulus"""
 
     name = "APWaveform"

--- a/bluepyemodel/ecode/customfromfile.py
+++ b/bluepyemodel/ecode/customfromfile.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class CustomFromFile(BPEM_stimulus):
-
     """CustomFromFile current stimulus to be loaded from a file"""
 
     name = "CustomFromFile"

--- a/bluepyemodel/ecode/dehyperpol.py
+++ b/bluepyemodel/ecode/dehyperpol.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class DeHyperpol(BPEM_stimulus):
-
     """DeHyperpol current stimulus
 
     The hyperpolarizing step is usually fixed at 150% of rheobase, and the hyperpolarizing step

--- a/bluepyemodel/ecode/firepattern.py
+++ b/bluepyemodel/ecode/firepattern.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class FirePattern(IDrest):
-
     """FirePattern current stimulus"""
 
     name = "FirePattern"

--- a/bluepyemodel/ecode/hyperdepol.py
+++ b/bluepyemodel/ecode/hyperdepol.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class HyperDepol(BPEM_stimulus):
-
     """HyperDepol current stimulus
 
     The hyperpolarizing step is usually fixed at 100% of rheobase, and the hyperpolarizing step

--- a/bluepyemodel/ecode/idrest.py
+++ b/bluepyemodel/ecode/idrest.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class IDrest(BPEM_stimulus):
-
     """IDrest current stimulus
 
     .. code-block:: none

--- a/bluepyemodel/ecode/iv.py
+++ b/bluepyemodel/ecode/iv.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class IV(IDrest):
-
     """IV current stimulus"""
 
     name = "IV"

--- a/bluepyemodel/ecode/noise.py
+++ b/bluepyemodel/ecode/noise.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class NoiseMixin(BPEM_stimulus):
-
     """Noise current stimulus"""
 
     name = "Noise"

--- a/bluepyemodel/ecode/noiseou3.py
+++ b/bluepyemodel/ecode/noiseou3.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 class NoiseOU3(NoiseMixin):
-
     """NoiseOU3 current stimulus"""
 
     name = "NoiseOU3"

--- a/bluepyemodel/ecode/probampanmda_ems.py
+++ b/bluepyemodel/ecode/probampanmda_ems.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class ProbAMPANMDA_EMS(BPEM_stimulus):
-
     """ProbAMPANMDA_EMS synapse current injection"""
 
     name = "ProbAMPANMDA_EMS"

--- a/bluepyemodel/ecode/ramp.py
+++ b/bluepyemodel/ecode/ramp.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class Ramp(BPEM_stimulus):
-
     """Ramp current stimulus
 
     .. code-block:: none

--- a/bluepyemodel/ecode/random_square_inputs.py
+++ b/bluepyemodel/ecode/random_square_inputs.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class MultipleRandomStepInputs(BPEM_stimulus):
-
     """MultipleRandomStepInputs current stimulus on one or several chosen sections
 
     .. code-block:: none

--- a/bluepyemodel/ecode/sahp.py
+++ b/bluepyemodel/ecode/sahp.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class sAHP(BPEM_stimulus):
-
     """sAHP current stimulus
 
     The long step (here amp) is usually fixed at 40% of rheobase, and the short step (here amp2)

--- a/bluepyemodel/ecode/sinespec.py
+++ b/bluepyemodel/ecode/sinespec.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class SineSpec(BPEM_stimulus):
-
     """SineSpec current stimulus"""
 
     name = "SineSpec"

--- a/bluepyemodel/ecode/stimulus.py
+++ b/bluepyemodel/ecode/stimulus.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
 
 
 class BPEM_stimulus(Stimulus):
-
     """Abstract current stimulus"""
 
     name = ""

--- a/bluepyemodel/ecode/subwhitenoise.py
+++ b/bluepyemodel/ecode/subwhitenoise.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 class SubWhiteNoise(BPEM_stimulus):
-
     """SubWhiteNoise current stimulus"""
 
     name = "SubWhiteNoise"

--- a/bluepyemodel/ecode/whitenoise.py
+++ b/bluepyemodel/ecode/whitenoise.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 class WhiteNoise(NoiseMixin):
-
     """WhiteNoise current stimulus"""
 
     name = "WhiteNoise"

--- a/bluepyemodel/efeatures_extraction/efeatures_extraction.py
+++ b/bluepyemodel/efeatures_extraction/efeatures_extraction.py
@@ -157,7 +157,11 @@ def extract_save_features_protocols(access_point, mapper=map):
     )
 
     fitness_calculator_config.init_from_bluepyefe(
-        efeatures, stimuli, current, access_point.pipeline_settings.threshold_efeature_std, targets_configuration.protocols_mapping
+        efeatures,
+        stimuli,
+        current,
+        access_point.pipeline_settings.threshold_efeature_std,
+        targets_configuration.protocols_mapping,
     )
 
     fitness_calculator_config = update_minimum_protocols_delay(

--- a/bluepyemodel/efeatures_extraction/efeatures_extraction.py
+++ b/bluepyemodel/efeatures_extraction/efeatures_extraction.py
@@ -157,7 +157,7 @@ def extract_save_features_protocols(access_point, mapper=map):
     )
 
     fitness_calculator_config.init_from_bluepyefe(
-        efeatures, stimuli, current, access_point.pipeline_settings.threshold_efeature_std
+        efeatures, stimuli, current, access_point.pipeline_settings.threshold_efeature_std, targets_configuration.protocols_mapping
     )
 
     fitness_calculator_config = update_minimum_protocols_delay(

--- a/bluepyemodel/efeatures_extraction/target.py
+++ b/bluepyemodel/efeatures_extraction/target.py
@@ -22,7 +22,6 @@ logger = logging.getLogger(__name__)
 
 
 class Target:
-
     """Describes an extraction (or optimisation) target"""
 
     def __init__(

--- a/bluepyemodel/efeatures_extraction/targets_configuration.py
+++ b/bluepyemodel/efeatures_extraction/targets_configuration.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 
 
 class TargetsConfiguration:
-
     """The goal of this class is to configure the targets and files metadata that will be
     used during efeature extraction"""
 

--- a/bluepyemodel/efeatures_extraction/targets_configuration.py
+++ b/bluepyemodel/efeatures_extraction/targets_configuration.py
@@ -42,6 +42,7 @@ class TargetsConfiguration:
         available_traces=None,
         available_efeatures=None,
         auto_targets=None,
+        protocols_mapping=None,
     ):
         """Init
 
@@ -101,6 +102,20 @@ class TargetsConfiguration:
                         "preferred_number_protocols": 1,
                         "tolerance": 10.,
                     }]
+            protocols_mapping (dict, optional): maps original protocol
+                identifiers to renamed versions for standardization.
+                Defaults to None if not provided.
+
+                Example:
+
+                .. code-block::
+
+                    {
+                        "IDRest_150": 'Step_150_hyp',
+                        "IDRest_200": 'Step_200_hyp',
+                        "IDRest_250": 'Step_250_hyp',
+                        "IV_-120": 'IV_-120_hyp',
+                    }
         """
 
         self.available_traces = available_traces
@@ -131,6 +146,8 @@ class TargetsConfiguration:
             self.protocols_rheobase = [protocols_rheobase]
         else:
             self.protocols_rheobase = protocols_rheobase
+
+        self.protocols_mapping = protocols_mapping
 
     def is_trace_available(self, trace):
         if self.available_traces:
@@ -308,4 +325,5 @@ class TargetsConfiguration:
             "targets": [t.as_dict() for t in self.targets],
             "protocols_rheobase": self.protocols_rheobase,
             "auto_targets": self.auto_targets,
+            "protocols_mapping": self.protocols_mapping,
         }

--- a/bluepyemodel/efeatures_extraction/targets_configurator.py
+++ b/bluepyemodel/efeatures_extraction/targets_configurator.py
@@ -42,7 +42,12 @@ class TargetsConfigurator:
         self.configuration = configuration
 
     def new_configuration(
-        self, files=None, targets=None, protocols_rheobase=None, auto_targets=None, protocols_mapping=None
+        self,
+        files=None,
+        targets=None,
+        protocols_rheobase=None,
+        auto_targets=None,
+        protocols_mapping=None,
     ):
         """Create a new configuration"""
 
@@ -53,7 +58,13 @@ class TargetsConfigurator:
         available_efeatures = self.access_point.get_available_efeatures()
 
         self.configuration = TargetsConfiguration(
-            files, targets, protocols_rheobase, available_traces, available_efeatures, auto_targets, protocols_mapping
+            files,
+            targets,
+            protocols_rheobase,
+            available_traces,
+            available_efeatures,
+            auto_targets,
+            protocols_mapping,
         )
 
     def load_configuration(self):

--- a/bluepyemodel/efeatures_extraction/targets_configurator.py
+++ b/bluepyemodel/efeatures_extraction/targets_configurator.py
@@ -27,7 +27,6 @@ logger = logging.getLogger(__name__)
 
 
 class TargetsConfigurator:
-
     """Handles the loading, saving and modification of a targets configuration"""
 
     def __init__(self, access_point, configuration=None):

--- a/bluepyemodel/efeatures_extraction/targets_configurator.py
+++ b/bluepyemodel/efeatures_extraction/targets_configurator.py
@@ -42,7 +42,7 @@ class TargetsConfigurator:
         self.configuration = configuration
 
     def new_configuration(
-        self, files=None, targets=None, protocols_rheobase=None, auto_targets=None
+        self, files=None, targets=None, protocols_rheobase=None, auto_targets=None, protocols_mapping=None
     ):
         """Create a new configuration"""
 
@@ -53,7 +53,7 @@ class TargetsConfigurator:
         available_efeatures = self.access_point.get_available_efeatures()
 
         self.configuration = TargetsConfiguration(
-            files, targets, protocols_rheobase, available_traces, available_efeatures, auto_targets
+            files, targets, protocols_rheobase, available_traces, available_efeatures, auto_targets, protocols_mapping
         )
 
     def load_configuration(self):
@@ -97,6 +97,7 @@ class TargetsConfigurator:
         files = self.access_point.pipeline_settings.files_for_extraction
         targets = self.access_point.pipeline_settings.targets
         protocols_rheobase = self.access_point.pipeline_settings.protocols_rheobase
+        protocols_mapping = self.access_point.pipeline_settings.protocols_mapping
 
         if not targets:
             auto_targets = self.access_point.pipeline_settings.auto_targets
@@ -109,5 +110,5 @@ class TargetsConfigurator:
                     )
                 auto_targets = get_auto_target_from_presets(auto_targets_presets)
 
-        self.new_configuration(files, targets, protocols_rheobase, auto_targets)
+        self.new_configuration(files, targets, protocols_rheobase, auto_targets, protocols_mapping)
         self.save_configuration()

--- a/bluepyemodel/efeatures_extraction/trace_file.py
+++ b/bluepyemodel/efeatures_extraction/trace_file.py
@@ -48,7 +48,6 @@ def list_ecodes_per_traces(traces, threshold_count=0):
 
 
 class TraceFile:
-
     """Contains the metadata of a trace file"""
 
     def __init__(

--- a/bluepyemodel/emodel_pipeline/emodel.py
+++ b/bluepyemodel/emodel_pipeline/emodel.py
@@ -39,7 +39,6 @@ def format_dict_for_resource(d):
 
 
 class EModel:
-
     """Contains all the information related to an optimized e-model, such as its parameters or
     its e-feature values and scores.
 

--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -20,7 +20,6 @@ import string
 
 
 class EModelMetadata:
-
     """Contains the metadata of an emodel such as its e-model name or its brain region. These
     metadata can be understood as a unique identifier of an e-model.
 

--- a/bluepyemodel/emodel_pipeline/emodel_pipeline.py
+++ b/bluepyemodel/emodel_pipeline/emodel_pipeline.py
@@ -37,7 +37,6 @@ logger = logging.getLogger()
 
 
 class EModel_pipeline:
-
     """The EModel_pipeline class is there to allow the execution of the steps
     of the e-model building pipeline using python (as opposed to the Luigi workflow).
 

--- a/bluepyemodel/emodel_pipeline/emodel_script.py
+++ b/bluepyemodel/emodel_pipeline/emodel_script.py
@@ -18,7 +18,6 @@ limitations under the License.
 
 
 class EModelScript:
-
     """Contains an emodel hoc file path."""
 
     def __init__(self, hoc_file_path=None, seed=None, workflow_id=None):

--- a/bluepyemodel/emodel_pipeline/emodel_settings.py
+++ b/bluepyemodel/emodel_pipeline/emodel_settings.py
@@ -25,7 +25,6 @@ logger = logging.getLogger(__name__)
 
 
 class EModelPipelineSettings:
-
     """Container for the settings used during the different steps of the e-model building pipeline.
     When using the "local" access point, these settings will be coming from the recipes.json file.
     When using the "nexus" access point, these settings will be coming from a resource of type

--- a/bluepyemodel/evaluation/efeature_configuration.py
+++ b/bluepyemodel/evaluation/efeature_configuration.py
@@ -18,7 +18,6 @@ limitations under the License.
 
 
 class EFeatureConfiguration:
-
     """Container for the definition of an EFeature"""
 
     def __init__(

--- a/bluepyemodel/evaluation/efel_feature_bpem.py
+++ b/bluepyemodel/evaluation/efel_feature_bpem.py
@@ -26,7 +26,6 @@ logger = logging.getLogger(__name__)
 
 
 class eFELFeatureBPEM(eFELFeature):
-
     """eFEL feature extra"""
 
     SERIALIZED_FIELDS = (

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -75,7 +75,6 @@ def _set_morphology_dependent_locations(recording, cell):
 
 
 class FitnessCalculatorConfiguration:
-
     """The goal of this class is to store the results of an efeature extraction (efeatures
     and protocols) or to contain the results of a previous extraction retrieved from an access
     point. This object is used for the creation of the fitness calculator.
@@ -399,9 +398,9 @@ class FitnessCalculatorConfiguration:
         if "extra_recordings" in protocol:
             for protocol_def in protocol["extra_recordings"]:
                 recordings.append(protocol_def)
-                protocol_def[
-                    "name"
-                ] = f"{protocol_name}.{protocol_def['name']}.{protocol_def['var']}"
+                protocol_def["name"] = (
+                    f"{protocol_name}.{protocol_def['name']}.{protocol_def['var']}"
+                )
 
         stimulus = deepcopy(protocol["stimuli"]["step"])
         if "holding" in protocol["stimuli"]:

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -27,7 +27,8 @@ from bluepyemodel.evaluation.evaluator import PRE_PROTOCOLS
 from bluepyemodel.evaluation.evaluator import define_location
 from bluepyemodel.evaluation.evaluator import seclist_to_sec
 from bluepyemodel.evaluation.protocol_configuration import ProtocolConfiguration
-from bluepyemodel.tools.utils import are_same_protocol, get_mapped_protocol_name
+from bluepyemodel.tools.utils import are_same_protocol
+from bluepyemodel.tools.utils import get_mapped_protocol_name
 
 logger = logging.getLogger(__name__)
 
@@ -311,7 +312,14 @@ class FitnessCalculatorConfiguration:
 
         self.efeatures.append(tmp_feature)
 
-    def init_from_bluepyefe(self, efeatures, protocols, currents, threshold_efeature_std, protocols_mapping=None):
+    def init_from_bluepyefe(
+        self,
+        efeatures,
+        protocols,
+        currents,
+        threshold_efeature_std,
+        protocols_mapping=None,
+    ):
         """Fill the configuration using the output of BluePyEfe"""
 
         if self.name_rmp_protocol and not any(
@@ -346,7 +354,6 @@ class FitnessCalculatorConfiguration:
                 for feature in efeatures[protocol_name][recording]:
                     p_name = get_mapped_protocol_name(protocol_name, protocols_mapping)
                     self._add_bluepyefe_efeature(feature, p_name, recording, threshold_efeature_std)
-
 
         # Add the current related features
         if currents and self.name_rmp_protocol and self.name_rin_protocol:
@@ -608,7 +615,10 @@ class FitnessCalculatorConfiguration:
                 "type": "Generation",
                 "activity": {
                     "type": "Activity",
-                    "followedWorkflow": {"type": "EModelWorkflow", "id": self.workflow_id},
+                    "followedWorkflow": {
+                        "type": "EModelWorkflow",
+                        "id": self.workflow_id,
+                    },
                 },
             }
         }

--- a/bluepyemodel/evaluation/fitness_calculator_configuration.py
+++ b/bluepyemodel/evaluation/fitness_calculator_configuration.py
@@ -339,10 +339,9 @@ class FitnessCalculatorConfiguration:
         self.protocols = []
         self.efeatures = []
 
-        if protocols_mapping:
-            self.validation_protocols = [
-                protocols_mapping.get(vp, vp) for vp in self.validation_protocols
-            ]
+        self.validation_protocols = [
+            get_mapped_protocol_name(vp, protocols_mapping) for vp in self.validation_protocols
+        ]
 
         for protocol_name, protocol in protocols.items():
             p_name = get_mapped_protocol_name(protocol_name, protocols_mapping)

--- a/bluepyemodel/evaluation/protocol_configuration.py
+++ b/bluepyemodel/evaluation/protocol_configuration.py
@@ -20,7 +20,6 @@ import copy
 
 
 class ProtocolConfiguration:
-
     """Container for the definition of a protocol"""
 
     def __init__(

--- a/bluepyemodel/evaluation/protocols.py
+++ b/bluepyemodel/evaluation/protocols.py
@@ -32,7 +32,6 @@ logger = logging.getLogger(__name__)
 
 
 class BPEMProtocol(ephys.protocols.SweepProtocol):
-
     """Base protocol"""
 
     def __init__(
@@ -97,7 +96,6 @@ class BPEMProtocol(ephys.protocols.SweepProtocol):
 
 
 class ResponseDependencies:
-
     """To add to a protocol to specify that it depends on the responses of other protocols"""
 
     def __init__(self, dependencies=None):
@@ -152,7 +150,6 @@ class ResponseDependencies:
 
 
 class ProtocolWithDependencies(BPEMProtocol, ResponseDependencies):
-
     """To add to a protocol to specify that it depends on the responses of other protocols"""
 
     def __init__(
@@ -188,7 +185,6 @@ class ProtocolWithDependencies(BPEMProtocol, ResponseDependencies):
 
 
 class ThresholdBasedProtocol(ProtocolWithDependencies):
-
     """Protocol having rheobase-rescaling capabilities. When using ThresholdBasedProtocol,
     the holding current amplitude and step amplitude of the stimulus will be ignored and
     replaced by values obtained from the holding current and rheobase of the cell model
@@ -226,7 +222,6 @@ class ThresholdBasedProtocol(ProtocolWithDependencies):
 
 
 class RMPProtocol(BPEMProtocol):
-
     """Protocol consisting of a step of amplitude zero"""
 
     def __init__(self, name, location, target_voltage, stimulus_duration=500.0):
@@ -287,7 +282,6 @@ class RMPProtocol(BPEMProtocol):
 
 
 class RinProtocol(ProtocolWithDependencies):
-
     """Protocol used to find the input resistance of a model"""
 
     def __init__(
@@ -581,7 +575,6 @@ class SearchHoldingCurrent(BPEMProtocol):
 
 
 class SearchThresholdCurrent(ProtocolWithDependencies):
-
     """Protocol used to find the threshold current (rheobase) of a model"""
 
     def __init__(
@@ -800,7 +793,6 @@ class SearchThresholdCurrent(ProtocolWithDependencies):
 
 
 class ProtocolRunner(ephys.protocols.Protocol):
-
     """Meta-protocol in charge of running the other protocols in the correct order"""
 
     def __init__(self, protocols, name="ProtocolRunner"):

--- a/bluepyemodel/model/model_configurator.py
+++ b/bluepyemodel/model/model_configurator.py
@@ -158,7 +158,9 @@ class ModelConfigurator:
                 stochastic=m.get("stochastic", None),
                 version=version,
                 temperature=temperature,
-                ljp_corrected=m.get("ljp_corrected")
-                if "ljp_corrected" in m
-                else m.get("isLjpCorrected", None),
+                ljp_corrected=(
+                    m.get("ljp_corrected")
+                    if "ljp_corrected" in m
+                    else m.get("isLjpCorrected", None)
+                ),
             )

--- a/bluepyemodel/tools/utils.py
+++ b/bluepyemodel/tools/utils.py
@@ -196,3 +196,10 @@ def are_same_protocol(name_a, name_b):
     if ecodes[0] == ecodes[1] and numpy.isclose(amps[0], amps[1]):
         return True
     return False
+
+def get_mapped_protocol_name(protocol_name, protocols_mapping):
+    if protocols_mapping:
+        for p in protocols_mapping:
+            if protocol_name.lower() in p.lower():
+                return protocols_mapping[p]
+    return protocol_name

--- a/bluepyemodel/tools/utils.py
+++ b/bluepyemodel/tools/utils.py
@@ -197,7 +197,11 @@ def are_same_protocol(name_a, name_b):
         return True
     return False
 
+
 def get_mapped_protocol_name(protocol_name, protocols_mapping):
+    """Returns the mapped protocol name from protocols_mapping if available;
+    otherwise, returns the original name."""
+
     if protocols_mapping:
         for p in protocols_mapping:
             if protocol_name.lower() in p.lower():


### PR DESCRIPTION
This PR introduces a feature allowing users to provide a protocols_mapping dictionary. This functionality enables the renaming of protocol identifiers post-extraction based on user-defined mappings.