### PR TITLE
Update default BluePyOpt version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "tqdm",
         "pyyaml",
         "gitpython",
-        "bluepyopt>=1.12.12",
+        "bluepyopt>=1.14.8",
         "bluepyefe>=2.2.0",
         "neurom>=3.0,<4.0",
         "efel>=3.1",


### PR DESCRIPTION
After the BluePyEModel release 0.0.74 adding [NrnSegmentSomaDistanceStepScaler](https://github.com/BlueBrain/BluePyEModel/blob/4835d6587ff49b40a77b26d1b8cc133d5f95c4cd/bluepyemodel/model/model.py#L27) BluePyOpt [release 1.14.8](https://github.com/BlueBrain/BluePyOpt/releases/tag/1.14.8) becomes a requirement.