### PR TITLE
do not use allen_notation in nexus registration/search

### DIFF
--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -138,7 +138,8 @@ class EModelMetadata:
         metadata = {}
 
         for k, v in vars(self).items():
-            if v and v != "None":
+            # we do not want allen_notation in resource metadata
+            if v and v != "None" and k != "allen_notation":
                 # rename species into subject and brain_region into brainLocation
                 if k == "species":
                     metadata["subject"] = v


### PR DESCRIPTION
We should not add allen_notation to a resource metadata when registering it.
In  the same way, we should not filter with allen_notation when searching for resources.