### PR TITLE
new argument for get_available_morphologies: skip_get_available_morph

### DIFF
--- a/bluepyemodel/access_point/access_point.py
+++ b/bluepyemodel/access_point/access_point.py
@@ -161,7 +161,7 @@ class DataAccessPoint:
     def store_distribution(self, distribution):
         """Store a channel distribution as a resource of type EModelChannelDistribution"""
 
-    def get_model_configuration(self):
+    def get_model_configuration(self, skip_get_available_morph=True):
         """Get the configuration of the model, including parameters, mechanisms and distributions"""
 
     def store_fitness_calculator_configuration(self, configuration):

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -452,9 +452,9 @@ class LocalAccessPoint(DataAccessPoint):
         patterns = ["*" + ext for ext in SUPPORTED_MORPHOLOGY_EXTENSIONS]
         return {morph_file.stem for pattern in patterns for morph_file in morph_dir.glob(pattern)}
 
-    def get_model_configuration(self, skip_get_available_morph=True):
+    def get_model_configuration(self, skip_get_available_morph=False):
         """Get the configuration of the model, including parameters, mechanisms and distributions
-        
+
         Args:
             skip_get_available_morph (bool): only used in nexus access point.
         """

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -452,8 +452,12 @@ class LocalAccessPoint(DataAccessPoint):
         patterns = ["*" + ext for ext in SUPPORTED_MORPHOLOGY_EXTENSIONS]
         return {morph_file.stem for pattern in patterns for morph_file in morph_dir.glob(pattern)}
 
-    def get_model_configuration(self):
-        """Get the configuration of the model, including parameters, mechanisms and distributions"""
+    def get_model_configuration(self, skip_get_available_morph=True):
+        """Get the configuration of the model, including parameters, mechanisms and distributions
+        
+        Args:
+            skip_get_available_morph (bool): only used in nexus access point.
+        """
 
         configuration = NeuronModelConfiguration(
             available_mechanisms=self.get_available_mechanisms(),

--- a/bluepyemodel/model/model_configurator.py
+++ b/bluepyemodel/model/model_configurator.py
@@ -52,9 +52,7 @@ class ModelConfigurator:
             self.configuration = NeuronModelConfiguration(
                 distributions=self.access_point.get_distributions(),
                 available_mechanisms=self.access_point.get_available_mechanisms(),
-                available_morphologies=self.access_point.get_available_morphologies(
-                    skip_get_available_morph=False
-                ),
+                available_morphologies=self.access_point.get_available_morphologies(),
             )
 
     def load_configuration(self):

--- a/bluepyemodel/model/model_configurator.py
+++ b/bluepyemodel/model/model_configurator.py
@@ -52,7 +52,9 @@ class ModelConfigurator:
             self.configuration = NeuronModelConfiguration(
                 distributions=self.access_point.get_distributions(),
                 available_mechanisms=self.access_point.get_available_mechanisms(),
-                available_morphologies=self.access_point.get_available_morphologies(),
+                available_morphologies=self.access_point.get_available_morphologies(
+                    skip_get_available_morph=False
+                ),
             )
 
     def load_configuration(self):


### PR DESCRIPTION
nexus access point can take more than 3 minutes to get all available morph resources. This is a lot for something that we only use in bluepyemodel.model.model_configuration.configure_model (in select morphology).

This is why we should allow to skip this step in nexus, and only set it to True when we create a new configuration with model_configurator.new_configuration