### PR TITLE
use camel case for nexus metadata

### DIFF
--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -694,9 +694,9 @@ class LocalAccessPoint(DataAccessPoint):
                 models.append(self.format_emodel_data(mod_data))
 
         filtered_models = []
-        api_metadata = self.emodel_metadata.for_resource()
+        api_metadata = self.emodel_metadata.as_dict()
         for m in models:
-            model_metadata = m.emodel_metadata.for_resource()
+            model_metadata = m.emodel_metadata.as_dict()
             for f, v in api_metadata.items():
                 if f in model_metadata and v != model_metadata[f]:
                     break

--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -19,6 +19,12 @@ limitations under the License.
 import string
 
 
+def update_metadata_dict(metadata_dict, var, new_key):
+    """Update metadata dict with new key and variable if not None."""
+    if var is not None and var != "None":
+        metadata_dict[new_key] = var
+
+
 class EModelMetadata:
     """Contains the metadata of an emodel such as its e-model name or its brain region. These
     metadata can be understood as a unique identifier of an e-model.
@@ -132,27 +138,27 @@ class EModelMetadata:
 
         return annotation_list
 
-    def get_metadata_dict(self):
+    def as_dict_for_resource(self):
         """Metadata as a dict, with keys consistent with nexus."""
 
-        metadata = {}
+        metadata_dict = {}
 
-        for k, v in vars(self).items():
-            # we do not want allen_notation in resource metadata
-            if v and v != "None" and k != "allen_notation":
-                # rename species into subject and brain_region into brainLocation
-                if k == "species":
-                    metadata["subject"] = v
-                elif k == "brain_region":
-                    metadata["brainLocation"] = v
-                else:
-                    metadata[k] = v
+        update_metadata_dict(metadata_dict, self.emodel, "eModel")
+        update_metadata_dict(metadata_dict, self.etype, "eType")
+        update_metadata_dict(metadata_dict, self.ttype, "tType")
+        update_metadata_dict(metadata_dict, self.mtype, "mType")
+        update_metadata_dict(metadata_dict, self.iteration, "iteration")
+        update_metadata_dict(metadata_dict, self.synapse_class, "synapseClass")
+        # rename species into subject and brain_region into brainLocation
+        update_metadata_dict(metadata_dict, self.species, "subject")
+        update_metadata_dict(metadata_dict, self.brain_region, "brainLocation")
+        # we do not want allen_notation in resource metadata
 
-        return metadata
+        return metadata_dict
 
     def filters_for_resource(self):
         """Metadata used for filtering, without the annotation list"""
-        return self.get_metadata_dict()
+        return self.as_dict_for_resource()
 
     def for_resource(self):
         """Metadata to add to a resource to register.
@@ -160,11 +166,15 @@ class EModelMetadata:
         DO NOT use for filtering. For filtering, use self.filters_for_resource() instead.
         """
 
-        metadata = self.get_metadata_dict()
+        metadata = self.as_dict_for_resource()
 
         metadata["annotation"] = self.annotation_list()
 
         return metadata
+    
+    def as_dict(self):
+        """Metadata as dict."""
+        return vars(self)
 
     def as_string(self, seed=None, use_allen_notation=True):
         s = ""

--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -171,7 +171,7 @@ class EModelMetadata:
         metadata["annotation"] = self.annotation_list()
 
         return metadata
-    
+
     def as_dict(self):
         """Metadata as dict."""
         return vars(self)

--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -156,9 +156,31 @@ class EModelMetadata:
 
         return metadata_dict
 
+    def as_dict_for_resource_legacy(self):
+        """Metadata as a dict, with keys consistent with legacy nexus."""
+
+        metadata_dict = {}
+
+        for k, v in vars(self).items():
+            # we do not want allen_notation in resource metadata
+            if v and v != "None" and k != "allen_notation":
+                # rename species into subject and brain_region into brainLocation
+                if k == "species":
+                    metadata_dict["subject"] = v
+                elif k == "brain_region":
+                    metadata_dict["brainLocation"] = v
+                else:
+                    metadata_dict[k] = v
+
+        return metadata_dict
+
     def filters_for_resource(self):
         """Metadata used for filtering, without the annotation list"""
         return self.as_dict_for_resource()
+
+    def filters_for_resource_legacy(self):
+        """Legacy metadata used for filtering, without the annotation list"""
+        return self.as_dict_for_resource_legacy()
 
     def for_resource(self):
         """Metadata to add to a resource to register.

--- a/tests/unit_tests/test_emodelmetadata.py
+++ b/tests/unit_tests/test_emodelmetadata.py
@@ -129,18 +129,23 @@ def test_annotation_list(metadata):
     assert annotation_list_2[0]["hasBody"]["label"] == "245_L5 PT CTX"
 
 
-def test_get_metadata_dict(metadata):
-    """Test get_metadata_dict method."""
+def test_as_dict_for_resource(metadata):
+    """Test as_dict_for_resource method."""
     metadata_dict = metadata_args.copy()
     metadata_dict["subject"] = metadata_dict.pop("species")
     metadata_dict["brainLocation"] = metadata_dict.pop("brain_region")
     metadata_dict["iteration"] = metadata_dict.pop("iteration_tag")
+    metadata_dict["eModel"] = metadata_dict.pop("emodel")
+    metadata_dict["eType"] = metadata_dict.pop("etype")
+    metadata_dict["tType"] = metadata_dict.pop("ttype")
+    metadata_dict["mType"] = metadata_dict.pop("mtype")
+    metadata_dict["synapseClass"] = metadata_dict.pop("synapse_class")
 
-    assert metadata.get_metadata_dict() == metadata_dict
+    assert metadata.as_dict_for_resource() == metadata_dict
 
     # with None values
     metadata = EModelMetadata(emodel="test")
-    assert metadata.get_metadata_dict() == {"emodel": "test"}
+    assert metadata.as_dict_for_resource() == {"eModel": "test"}
 
 
 def test_filters_for_resource(metadata):
@@ -149,12 +154,17 @@ def test_filters_for_resource(metadata):
     metadata_dict["subject"] = metadata_dict.pop("species")
     metadata_dict["brainLocation"] = metadata_dict.pop("brain_region")
     metadata_dict["iteration"] = metadata_dict.pop("iteration_tag")
+    metadata_dict["eModel"] = metadata_dict.pop("emodel")
+    metadata_dict["eType"] = metadata_dict.pop("etype")
+    metadata_dict["tType"] = metadata_dict.pop("ttype")
+    metadata_dict["mType"] = metadata_dict.pop("mtype")
+    metadata_dict["synapseClass"] = metadata_dict.pop("synapse_class")
 
-    assert metadata.get_metadata_dict() == metadata_dict
+    assert metadata.filters_for_resource() == metadata_dict
 
     # with None values
     metadata = EModelMetadata(emodel="test")
-    assert metadata.get_metadata_dict() == {"emodel": "test"}
+    assert metadata.filters_for_resource() == {"eModel": "test"}
 
 
 def test_for_resource(metadata):
@@ -164,14 +174,19 @@ def test_for_resource(metadata):
     metadata_dict["brainLocation"] = metadata_dict.pop("brain_region")
     metadata_dict["iteration"] = metadata_dict.pop("iteration_tag")
     metadata_dict["annotation"] = metadata.annotation_list()
+    metadata_dict["eModel"] = metadata_dict.pop("emodel")
+    metadata_dict["eType"] = metadata_dict.pop("etype")
+    metadata_dict["tType"] = metadata_dict.pop("ttype")
+    metadata_dict["mType"] = metadata_dict.pop("mtype")
+    metadata_dict["synapseClass"] = metadata_dict.pop("synapse_class")
 
     assert metadata.for_resource() == metadata_dict
 
     # with None values
     metadata = EModelMetadata(emodel="test", mtype="mtype_test")
     assert metadata.for_resource() == {
-        "emodel": "test",
-        "mtype": "mtype_test",
+        "eModel": "test",
+        "mType": "mtype_test",
         "annotation": [
             {
                 "type": [

--- a/tests/unit_tests/test_emodelmetadata.py
+++ b/tests/unit_tests/test_emodelmetadata.py
@@ -148,6 +148,25 @@ def test_as_dict_for_resource(metadata):
     assert metadata.as_dict_for_resource() == {"eModel": "test"}
 
 
+def test_as_dict_for_resource_legacy(metadata):
+    """Test as_dict_for_resource_legacy method."""
+    metadata_dict = metadata_args.copy()
+    metadata_dict["subject"] = metadata_dict.pop("species")
+    metadata_dict["brainLocation"] = metadata_dict.pop("brain_region")
+    metadata_dict["iteration"] = metadata_dict.pop("iteration_tag")
+    metadata_dict["emodel"] = metadata_dict.pop("emodel")
+    metadata_dict["etype"] = metadata_dict.pop("etype")
+    metadata_dict["ttype"] = metadata_dict.pop("ttype")
+    metadata_dict["mtype"] = metadata_dict.pop("mtype")
+    metadata_dict["synapse_class"] = metadata_dict.pop("synapse_class")
+
+    assert metadata.as_dict_for_resource_legacy() == metadata_dict
+
+    # with None values
+    metadata = EModelMetadata(emodel="test")
+    assert metadata.as_dict_for_resource_legacy() == {"emodel": "test"}
+
+
 def test_filters_for_resource(metadata):
     """Test filters_for_resource method."""
     metadata_dict = metadata_args.copy()
@@ -165,6 +184,25 @@ def test_filters_for_resource(metadata):
     # with None values
     metadata = EModelMetadata(emodel="test")
     assert metadata.filters_for_resource() == {"eModel": "test"}
+
+
+def test_filters_for_resource_legacy(metadata):
+    """Test filters_for_resource_legacy method."""
+    metadata_dict = metadata_args.copy()
+    metadata_dict["subject"] = metadata_dict.pop("species")
+    metadata_dict["brainLocation"] = metadata_dict.pop("brain_region")
+    metadata_dict["iteration"] = metadata_dict.pop("iteration_tag")
+    metadata_dict["emodel"] = metadata_dict.pop("emodel")
+    metadata_dict["etype"] = metadata_dict.pop("etype")
+    metadata_dict["ttype"] = metadata_dict.pop("ttype")
+    metadata_dict["mtype"] = metadata_dict.pop("mtype")
+    metadata_dict["synapse_class"] = metadata_dict.pop("synapse_class")
+
+    assert metadata.filters_for_resource_legacy() == metadata_dict
+
+    # with None values
+    metadata = EModelMetadata(emodel="test")
+    assert metadata.filters_for_resource_legacy() == {"emodel": "test"}
 
 
 def test_for_resource(metadata):


### PR DESCRIPTION
We'll have to force nexus team to update all nexus resources we have uploaded for OBP with camel case metadata if we merge this