### PR TITLE
do not take into account allen_notation when filtering the emodels

### DIFF
--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -698,7 +698,7 @@ class LocalAccessPoint(DataAccessPoint):
         for m in models:
             model_metadata = m.emodel_metadata.as_dict()
             for f, v in api_metadata.items():
-                if f in model_metadata and v != model_metadata[f]:
+                if f in model_metadata and v != model_metadata[f] and f != "allen_notation":
                     break
             else:
                 filtered_models.append(m)


### PR DESCRIPTION
Motivation: For edge case where two same e-models, but one has the allen_notation, and the other one still has allen_notation as None. Different allen_notation do not mean that the e-models are different, it can just be that one has fetched the information from nexus, while the other one (e.g. made with a local access point) has not set it.