### PR TITLE
update gene selection to include me-type

### DIFF
--- a/bluepyemodel/icselector/icselector.py
+++ b/bluepyemodel/icselector/icselector.py
@@ -138,7 +138,7 @@ class ICSelector:
         # === Get genes from gene mapping file
         logging.info("\n===============\nGenes Selection\n===============")
         genes = self._gene_selector.select_from_mettype(mettype)
-        # logging.info(str(self._gene_selector))
+        logging.info(str(self._gene_selector))
 
         # === Map genes to channels
         for gene, info in genes.items():

--- a/bluepyemodel/icselector/icselector.py
+++ b/bluepyemodel/icselector/icselector.py
@@ -123,29 +123,29 @@ class ICSelector:
         else:
             logging.warning("Could not determine mechanism for gene %s", gene_name)
 
-    def _set_parameters_from_ttype(self):
+    def _set_parameters_from_mettype(self):
         """Copy parameters from selected genes to mechanims."""
 
         for gene_name in self._gene_selector.selected_genes:
             self.__set_parameters_from_gene(gene_name)
 
-    def _select_genes_from_ttype(self, key_words):
+    def _select_genes_from_mettype(self, mettype):
         """Select genes from key words.
         Args:
-            key_words (list [str]): list of keys to select genes
+            mettype (dict): dict containing the etype, mtype and ttype
         """
 
         # === Get genes from gene mapping file
         logging.info("\n===============\nGenes Selection\n===============")
-        genes = self._gene_selector.select_from_ttype(key_words)
-        logging.info(str(self._gene_selector))
+        genes = self._gene_selector.select_from_mettype(mettype)
+        # logging.info(str(self._gene_selector))
 
         # === Map genes to channels
         for gene, info in genes.items():
             if gene in self._gene_to_ic:
                 info["channel"] = self._gene_to_ic[gene]
 
-    def _select_mechanisms_from_ttype(self):
+    def _select_mechanisms_from_mettype(self):
         """Select mechanisms from previously selected genes."""
 
         logging.info("\n==================\nChannels Selection\n==================")
@@ -259,12 +259,12 @@ class ICSelector:
         logging.info(str(config))
         return config
 
-    def get_cell_config_from_ttype(self, key_words):
+    def get_cell_config_from_mettype(self, mettype):
         """Get all information related to cell model configuration from
         mechanisms selected based on genetic expression profiles.
 
         Args:
-            key_words: keys to select MET-types
+            mettype (dict): Dictionary containing the MET-types
 
         Returns:
             parameters (list [dict,]): mechanism parameters per compartment
@@ -274,9 +274,9 @@ class ICSelector:
         """
 
         # Perform selections
-        self._select_genes_from_ttype(key_words)
-        self._set_parameters_from_ttype()
-        self._select_mechanisms_from_ttype()
+        self._select_genes_from_mettype(mettype)
+        self._set_parameters_from_mettype()
+        self._select_mechanisms_from_mettype()
 
         # Get configuration
         mechs = self._model_selector.get_mechanisms()

--- a/bluepyemodel/icselector/modules/gene_selector.py
+++ b/bluepyemodel/icselector/modules/gene_selector.py
@@ -187,8 +187,7 @@ class GeneSelector:
             ) from exc
 
         # Store result
-        self.selected_met_types = np.unique([f"{v[0]} - {v[1]}" for v in df.index.values])
-        df = df.droplevel([0, 1])
+        self.selected_met_types = [f"{me_type} - {t_type}"]
 
         names = genes.columns.values
         for name in names:

--- a/bluepyemodel/icselector/modules/gene_selector.py
+++ b/bluepyemodel/icselector/modules/gene_selector.py
@@ -38,6 +38,30 @@ class GeneSelector:
         self.selected_met_types = []
 
     @staticmethod
+    def _filter(df, keys):
+        """Rules for filtering the columns of Yann's gene map.
+        Args:
+            df (DataFrame): subset of Yann's table
+            keys (list [str]): list of strings to filter columns
+        Returns:
+            df (DataFrame): subset of the table
+        """
+
+        # First filter on exact match
+        for name in df.index.names:
+            crit = df.index.get_level_values(name).isin(keys)
+            # Only apply filter if exact match was found
+            if not np.all(~crit):
+                df = df[crit]
+        # Then filter on partial match
+        for key in keys:
+            new_df = df.filter(regex=key, axis=0)
+            # Only apply filter if partial match was found
+            if not new_df.shape[0] == 0:
+                df = new_df
+        return df
+
+    @staticmethod
     def _get_gene_presence(gene):
         """Determine if a gene is present or not.
 

--- a/bluepyemodel/icselector/modules/gene_selector.py
+++ b/bluepyemodel/icselector/modules/gene_selector.py
@@ -37,7 +37,6 @@ class GeneSelector:
         self.selected_genes = {}
         self.selected_met_types = []
 
-
     @staticmethod
     def _get_gene_presence(gene):
         """Determine if a gene is present or not.

--- a/bluepyemodel/icselector/modules/gene_selector.py
+++ b/bluepyemodel/icselector/modules/gene_selector.py
@@ -172,18 +172,17 @@ class GeneSelector:
         """
 
         df = self._gene_map
-        me_type = f"{mettype["etype"]}_{mettype["mtype"]}"
-        ttype = mettype["ttype"]
 
-        # replace spaces with double underscore in ttype since it is not supported
-        df['t-type'] = df['t-type'].str.replace(' ', '__')
-        ttype = ttype.str.replace(' ', '__')
+        me_type = f"{mettype['mtype']}_{mettype['etype']}"
+        t_type = mettype["ttype"]
 
-        # Filter on met-type
-        genes = df[(df['me-type'] == me_type) & (df['t-type'] == ttype)]
+        # replace double underscores with spaces
+        t_type = t_type.replace('__', ' ')
 
-        if genes.empty:
-            raise ValueError(f"No genes found for me-type: {me_type} and t-type: {ttype}")
+        try:
+            genes = df.loc[(me_type, t_type)]
+        except KeyError:
+            raise ValueError(f"No records found for me-type: {me_type} and t-type: {t_type}")
 
         # Store result
         self.selected_met_types = np.unique([f"{v[0]} - {v[1]}" for v in df.index.values])

--- a/bluepyemodel/icselector/modules/gene_selector.py
+++ b/bluepyemodel/icselector/modules/gene_selector.py
@@ -40,9 +40,11 @@ class GeneSelector:
     @staticmethod
     def _filter(df, keys):
         """Rules for filtering the columns of Yann's gene map.
+
         Args:
             df (DataFrame): subset of Yann's table
             keys (list [str]): list of strings to filter columns
+
         Returns:
             df (DataFrame): subset of the table
         """

--- a/bluepyemodel/model/model_configurator.py
+++ b/bluepyemodel/model/model_configurator.py
@@ -101,8 +101,11 @@ class ModelConfigurator:
         ic_map_path = self.access_point.load_ic_map()
 
         selector = icselector.ICSelector(ic_map_path, gene_map_path)
-        parameters, mechanisms, distributions, nexus_keys = selector.get_cell_config_from_ttype(
-            self.access_point.emodel_metadata.ttype
+        mettype = {'etype': self.access_point.emodel_metadata.etype,
+                   'mtype': self.access_point.emodel_metadata.mtype,
+                   'ttype': self.access_point.emodel_metadata.ttype}
+        parameters, mechanisms, distributions, nexus_keys = selector.get_cell_config_from_mettype(
+            mettype
         )
 
         return parameters, mechanisms, distributions, nexus_keys


### PR DESCRIPTION
Previously, genes were selected solely based on their `ttype`. In the event that the same ttype occurs with different me-type combinations, we are now incorporating the `me-type` as an additional filtering criterion. The filtering process has also been simplified. Additionally, this PR addresses the case where no match is found in the gene map.