### PR TITLE
Better checkpoint_path filtering for parameter evolution plot

### DIFF
--- a/bluepyemodel/emodel_pipeline/emodel_pipeline.py
+++ b/bluepyemodel/emodel_pipeline/emodel_pipeline.py
@@ -248,11 +248,11 @@ class EModel_pipeline:
         # Filter the checkpoints to plot
         checkpoint_paths = []
         for chkp_path in chkp_paths:
-            if self.access_point.emodel_metadata.emodel not in chkp_path:
+            if self.access_point.emodel_metadata.emodel not in chkp_path.split("/"):
                 continue
             if (
                 self.access_point.emodel_metadata.iteration
-                and self.access_point.emodel_metadata.iteration not in chkp_path
+                and self.access_point.emodel_metadata.iteration not in chkp_path.split("/")
             ):
                 continue
             checkpoint_paths.append(chkp_path)


### PR DESCRIPTION
Should solve edge case where one emodel name is a substring of another emodel name, leading to bad checkpoint path filtering for evolution parameter density plots.