### PR TITLE
fix morph_modifiers check

### DIFF
--- a/bluepyemodel/evaluation/evaluation.py
+++ b/bluepyemodel/evaluation/evaluation.py
@@ -264,9 +264,9 @@ def get_evaluator_from_access_point(
         record_ions_and_currents=record_ions_and_currents
     )
 
-    if model_configuration.morph_modifiers:
+    if model_configuration.morph_modifiers is not None:
         morph_modifiers = model_configuration.morph_modifiers
-    elif access_point.pipeline_settings:
+    elif access_point.pipeline_settings is not None:
         morph_modifiers = access_point.pipeline_settings.morph_modifiers
     else:
         morph_modifiers = None


### PR DESCRIPTION
When morph_modifiers was an empty list, the check incorrectly evaluated it as false, leading to the use of default morph_modifiers