### PR TITLE
A better ValueError message for inccorect location

### DIFF
--- a/bluepyemodel/evaluation/evaluator.py
+++ b/bluepyemodel/evaluation/evaluator.py
@@ -85,7 +85,10 @@ def define_location(definition):
             return soma_loc
         if definition["location"] == "ais":
             return ais_loc
-        raise ValueError("Only soma and ais are implemented for CompRecording")
+        raise ValueError(
+            "Only soma and ais are implemented for CompRecording"
+            f' for {definition["name"]} at {definition["location"]}'
+        )
 
     if definition["type"] == "somadistance":
         return NrnSomaDistanceCompLocation(

--- a/bluepyemodel/evaluation/evaluator.py
+++ b/bluepyemodel/evaluation/evaluator.py
@@ -86,8 +86,8 @@ def define_location(definition):
         if definition["location"] == "ais":
             return ais_loc
         raise ValueError(
-            "Only soma and ais are implemented for CompRecording"
-            f' for {definition["name"]} at {definition["location"]}'
+            "Only soma and ais are implemented for CompRecording."
+            f' Cannot load {definition["name"]} at {definition["location"]}.'
         )
 
     if definition["type"] == "somadistance":


### PR DESCRIPTION
Raise a better error message in `define_location` for `CompRecording`