### PR TITLE
Add schemas when registering / updating nexus resources

### DIFF
--- a/bluepyemodel/access_point/access_point.py
+++ b/bluepyemodel/access_point/access_point.py
@@ -215,6 +215,9 @@ class DataAccessPoint:
         description=None,
     ):
         """Store hoc file produced by export_sonata"""
+    
+    def update_emodel_images(self, seed, keep_old_images=False):
+        """Update an EModel resource with local emodel plots if access_point is nexus."""
 
     def optimisation_state(self, seed=None, continue_opt=False):
         """Return the state of the optimisation.

--- a/bluepyemodel/access_point/access_point.py
+++ b/bluepyemodel/access_point/access_point.py
@@ -215,7 +215,7 @@ class DataAccessPoint:
         description=None,
     ):
         """Store hoc file produced by export_sonata"""
-    
+
     def update_emodel_images(self, seed, keep_old_images=False):
         """Update an EModel resource with local emodel plots if access_point is nexus."""
 

--- a/bluepyemodel/access_point/forge_access_point.py
+++ b/bluepyemodel/access_point/forge_access_point.py
@@ -341,7 +341,7 @@ class NexusForgeAccessPoint:
 
     def add_images_to_resource(self, images, resource, filters_existence=None):
         """Attach images to a resource.
-        
+
         Args:
             images (list of str): list of local paths to images
             resource (kgforge.core.Resource): resource to attach the images to
@@ -389,6 +389,7 @@ class NexusForgeAccessPoint:
             images (list): paths to images to be attached to the resource
             type_ (str): type of the resource. Will be used to get the schemas.
         """
+        # pylint: disable=protected-access
 
         if "type" not in resource_description:
             raise AccessPointException("The resource description should contain 'type'.")

--- a/bluepyemodel/access_point/forge_access_point.py
+++ b/bluepyemodel/access_point/forge_access_point.py
@@ -347,6 +347,7 @@ class NexusForgeAccessPoint:
         replace=False,
         distributions=None,
         images=None,
+        type_=None,
     ):
         """Register a resource from its dictionary description.
 
@@ -359,6 +360,7 @@ class NexusForgeAccessPoint:
             replace (bool): whether to replace resource if found with filters_existence
             distributions (list): paths to resource object as json and other distributions
             images (list): paths to images to be attached to the resource
+            type_ (str): type of the resource. Will be used to get the schemas.
         """
 
         if "type" not in resource_description:
@@ -413,7 +415,16 @@ class NexusForgeAccessPoint:
                     about=resource_type,
                 )
 
-        self.forge.register(resource)
+        # validate with Entity schema at creation.
+        # validation with EModelWorkflow schema is done at a later step,
+        # when EModelWorkflow resource is complete
+        if type_ == "EModelWorkflow":
+            type_ = "Entity"
+        # validate schemas
+        schema_id = self.forge._model.schema_id(type_)
+        self.forge.validate(resource, type_=type_)
+
+        self.forge.register(resource, schema_id=schema_id)
 
     def retrieve(self, id_):
         """Retrieve a resource based on its id"""
@@ -712,6 +723,7 @@ class NexusForgeAccessPoint:
             replace=replace,
             distributions=distributions,
             images=nexus_images,
+            type_=type_,
         )
 
     def update_distribution(self, resource, metadata_str, object_):

--- a/bluepyemodel/access_point/forge_access_point.py
+++ b/bluepyemodel/access_point/forge_access_point.py
@@ -349,7 +349,7 @@ class NexusForgeAccessPoint:
                 can be used to search for existence of resource on nexus.
                 Used to get image type if cannot be extracted from image path.
         """
-        resource = Dataset.from_resource(self.forge, resource)
+        resource = Dataset.from_resource(self.forge, resource, store_metadata=True)
         if filters_existence is None:
             filters_existence = {}
         for path in images:
@@ -364,6 +364,7 @@ class NexusForgeAccessPoint:
                 content_type=f"application/{path.split('.')[-1]}",
                 about=resource_type,
             )
+        return resource
 
     def register(
         self,
@@ -428,7 +429,7 @@ class NexusForgeAccessPoint:
                 resource.add_distribution(path, content_type=f"application/{path.split('.')[-1]}")
 
         if images:
-            self.add_images_to_resource(images, resource, filters_existence)
+            resource = self.add_images_to_resource(images, resource, filters_existence)
 
         # validate with Entity schema at creation.
         # validation with EModelWorkflow schema is done at a later step,

--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -340,6 +340,10 @@ class LocalAccessPoint(DataAccessPoint):
 
         return f"{self.emodel_metadata.emodel}__{seed}"
 
+    def store_or_update_emodel(self, emodel):
+        """Calls store_emodel."""
+        self.store_emodel(emodel)
+
     def store_emodel(self, emodel):
         """Store an emodel obtained from BluePyOpt in the final.json. Note that if a model in the
         final.json has the same key (emodel__iteration_tag__seed), it will be overwritten.

--- a/bluepyemodel/access_point/nexus.py
+++ b/bluepyemodel/access_point/nexus.py
@@ -698,7 +698,7 @@ class NexusAccessPoint(DataAccessPoint):
             ids_dict = emodel_workflow.get_related_nexus_ids()
             if "generates" in ids_dict:
                 resource.generates = ids_dict["generates"]
-                schema_type = EModelWorkflow
+                schema_type = "EModelWorkflow"
             if "hasPart" in ids_dict:
                 resource.hasPart = ids_dict["hasPart"]
 

--- a/bluepyemodel/access_point/nexus.py
+++ b/bluepyemodel/access_point/nexus.py
@@ -692,11 +692,13 @@ class NexusAccessPoint(DataAccessPoint):
             )
         # if present on nexus -> update its state
         else:
+            schema_type = "Entity"
             resource = resources[0]
             resource.state = emodel_workflow.state
             ids_dict = emodel_workflow.get_related_nexus_ids()
             if "generates" in ids_dict:
                 resource.generates = ids_dict["generates"]
+                schema_type = EModelWorkflow
             if "hasPart" in ids_dict:
                 resource.hasPart = ids_dict["hasPart"]
 
@@ -705,7 +707,11 @@ class NexusAccessPoint(DataAccessPoint):
                 resource, self.emodel_metadata.as_string(), emodel_workflow
             )
 
-            self.access_point.forge.update(updated_resource)
+            # validate schemas
+            schema_id = self.access_point.forge._model.schema_id(schema_type)
+            self.access_point.forge.validate(resource, type_=schema_type)
+
+            self.access_point.forge.update(updated_resource, schema_id=schema_id)
 
     def get_emodel(self, seed=None):
         """Fetch an emodel"""
@@ -1256,6 +1262,7 @@ class NexusAccessPoint(DataAccessPoint):
         self.access_point.register(
             resource_description=payload,
             distributions=[morphology_path],
+            type_="NeuronMorphology",
         )
 
     def store_hocs(

--- a/bluepyemodel/access_point/nexus.py
+++ b/bluepyemodel/access_point/nexus.py
@@ -673,6 +673,7 @@ class NexusAccessPoint(DataAccessPoint):
 
     def store_or_update_emodel_workflow(self, emodel_workflow):
         """If emodel workflow is not on nexus, store it. If it is, fetch it and update its state"""
+        # pylint: disable=protected-access
         type_ = "EModelWorkflow"
 
         filters = {"type": type_}
@@ -711,8 +712,8 @@ class NexusAccessPoint(DataAccessPoint):
             self.access_point.forge.update(updated_resource, schema_id=schema_id)
 
     def update_emodel_images(self, seed, keep_old_images=False):
-        """Update an EModel resource with local emodel plots.
-        """
+        """Update an EModel resource with local emodel plots."""
+        # pylint: disable=protected-access
         type_ = "EModel"
 
         filters = {"type": type_}
@@ -722,13 +723,17 @@ class NexusAccessPoint(DataAccessPoint):
         filters["seed"] = int(seed)
         filters_legacy["seed"] = int(seed)
         resources = self.access_point.fetch_legacy_compatible(filters, filters_legacy)
+        if resources is None:
+            return
         em_r = resources[0]
         if not keep_old_images:
-            em_r.image = [] # remove any previous images
+            em_r.image = []  # remove any previous images
 
         em = self.get_emodel(seed=seed)
 
-        em_r = self.access_point.add_images_to_resource(em.as_dict()["nexus_images"], em_r, filters_existence=None)
+        em_r = self.access_point.add_images_to_resource(
+            em.as_dict()["nexus_images"], em_r, filters_existence=None
+        )
         schema_id = self.access_point.forge._model.schema_id("EModel")
 
         self.access_point.forge.update(em_r, schema_id=schema_id)
@@ -752,9 +757,10 @@ class NexusAccessPoint(DataAccessPoint):
         emodel.emodel_metadata = copy.deepcopy(self.emodel_metadata)
 
         return emodel
-    
+
     def store_or_update_emodel(self, emodel):
         """Update emodel if already present on nexus. If not, store it."""
+        # pylint: disable=protected-access
         type_ = "EModel"
 
         filters = {"type": type_}
@@ -766,8 +772,9 @@ class NexusAccessPoint(DataAccessPoint):
         resources = self.access_point.fetch_legacy_compatible(filters, filters_legacy)
 
         if resources is None:
-            return self.store_emodel(emodel)
-        
+            self.store_emodel(emodel)
+            return
+
         em_r = resources[0]
         emodel_dict = emodel.as_dict()
 
@@ -778,10 +785,7 @@ class NexusAccessPoint(DataAccessPoint):
         em_r.score = emodel.fitness
 
         schema_id = self.access_point.forge._model.schema_id("EModel")
-        setattr(em_r, '_synchronized', False)
         self.access_point.forge.update(em_r, schema_id=schema_id)
-
-
 
     def store_emodel(self, emodel, description=None):
         """Store an EModel on Nexus"""

--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -130,24 +130,15 @@ class EModelMetadata:
         """Returns an annotation list containing mtype, etype and ttype annotations"""
         annotation_list = [
             {
-                "type": [
-                    "QualityAnnotation",
-                    "Annotation"
-                ],
+                "type": ["QualityAnnotation", "Annotation"],
                 "hasBody": {
                     "id": "https://bbp.epfl.ch/ontologies/core/bmo/AnalysisSuitable",
-                    "type": [
-                        "AnnotationBody",
-                        "DataScope"
-                    ],
-                    "label": "Analysis Suitable"
+                    "type": ["AnnotationBody", "DataScope"],
+                    "label": "Analysis Suitable",
                 },
-                "motivatedBy": {
-                    "id": "quality:Assessment",
-                    "type": "Motivation"
-                },
+                "motivatedBy": {"id": "quality:Assessment", "type": "Motivation"},
                 "name": "Data usage scope annotation",
-                "note": "Analysis can be run on this model."
+                "note": "Analysis can be run on this model.",
             }
         ]
         if self.etype:

--- a/bluepyemodel/emodel_pipeline/emodel_metadata.py
+++ b/bluepyemodel/emodel_pipeline/emodel_metadata.py
@@ -128,7 +128,28 @@ class EModelMetadata:
 
     def annotation_list(self):
         """Returns an annotation list containing mtype, etype and ttype annotations"""
-        annotation_list = []
+        annotation_list = [
+            {
+                "type": [
+                    "QualityAnnotation",
+                    "Annotation"
+                ],
+                "hasBody": {
+                    "id": "https://bbp.epfl.ch/ontologies/core/bmo/AnalysisSuitable",
+                    "type": [
+                        "AnnotationBody",
+                        "DataScope"
+                    ],
+                    "label": "Analysis Suitable"
+                },
+                "motivatedBy": {
+                    "id": "quality:Assessment",
+                    "type": "Motivation"
+                },
+                "name": "Data usage scope annotation",
+                "note": "Analysis can be run on this model."
+            }
+        ]
         if self.etype:
             annotation_list.append(self.etype_annotation_dict())
         if self.mtype:

--- a/bluepyemodel/tasks/emodel_creation/optimisation.py
+++ b/bluepyemodel/tasks/emodel_creation/optimisation.py
@@ -1289,7 +1289,7 @@ class PlotModels(WorkflowTaskRequiringMechanisms):
         )
         
         if isinstance(self.access_point, NexusAccessPoint):
-            self.access_point.update_emodel_images(seed=self.seed)
+            self.access_point.update_emodel_images(seed=self.seed, keep_old_images=False)
 
     def output(self):
         """ """
@@ -1371,7 +1371,7 @@ class PlotValidatedDistributions(WorkflowTaskRequiringMechanisms):
         )
 
         if isinstance(self.access_point, NexusAccessPoint):
-            self.access_point.update_emodel_images(seed=self.seed)
+            self.access_point.update_emodel_images(seed=self.seed, keep_old_images=False)
         
 
     def output(self):

--- a/bluepyemodel/tasks/emodel_creation/optimisation.py
+++ b/bluepyemodel/tasks/emodel_creation/optimisation.py
@@ -1287,7 +1287,7 @@ class PlotModels(WorkflowTaskRequiringMechanisms):
             phase_plot_settings=phase_plot_settings,
             sinespec_settings=sinespec_settings,
         )
-        
+
         if isinstance(self.access_point, NexusAccessPoint):
             self.access_point.update_emodel_images(seed=self.seed, keep_old_images=False)
 
@@ -1371,8 +1371,9 @@ class PlotValidatedDistributions(WorkflowTaskRequiringMechanisms):
         )
 
         if isinstance(self.access_point, NexusAccessPoint):
-            self.access_point.update_emodel_images(seed=self.seed, keep_old_images=False)
-        
+            seeds = [emodel.seed for emodel in self.access_point.get_emodels()]
+            for seed in seeds:
+                self.access_point.update_emodel_images(seed=seed, keep_old_images=False)
 
     def output(self):
         """ """

--- a/bluepyemodel/tasks/emodel_creation/optimisation.py
+++ b/bluepyemodel/tasks/emodel_creation/optimisation.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import luigi
 
 from bluepyemodel.access_point.access_point import OptimisationState
+from bluepyemodel.access_point.nexus import NexusAccessPoint
 from bluepyemodel.efeatures_extraction.efeatures_extraction import extract_save_features_protocols
 from bluepyemodel.efeatures_extraction.targets_configurator import TargetsConfigurator
 from bluepyemodel.emodel_pipeline.plotting import optimisation
@@ -1286,6 +1287,9 @@ class PlotModels(WorkflowTaskRequiringMechanisms):
             phase_plot_settings=phase_plot_settings,
             sinespec_settings=sinespec_settings,
         )
+        
+        if isinstance(self.access_point, NexusAccessPoint):
+            self.access_point.update_emodel_images(seed=self.seed)
 
     def output(self):
         """ """
@@ -1365,6 +1369,10 @@ class PlotValidatedDistributions(WorkflowTaskRequiringMechanisms):
             plot_bAP_EPSP=False,
             only_validated=True,
         )
+
+        if isinstance(self.access_point, NexusAccessPoint):
+            self.access_point.update_emodel_images(seed=self.seed)
+        
 
     def output(self):
         """ """

--- a/bluepyemodel/validation/validation.py
+++ b/bluepyemodel/validation/validation.py
@@ -130,6 +130,6 @@ def validate(access_point, mapper, preselect_for_validation=False):
             )
         )
 
-        access_point.store_emodel(model)
+        access_point.store_or_update_emodel(model)
 
     return emodels


### PR DESCRIPTION
- add 'analysis suitable' notation
- refactor adding images to resources
- new function to update an EModel resource with images
- update an emodel with images after plotting in luigi pipeline when access point is nexus
- update emodel after validation instead of deprecating it and re-registering it (it was messing with emodel ids)