### PR TITLE
fix thumbanil for absolute amplitude protocols

### DIFF
--- a/bluepyemodel/tools/utils.py
+++ b/bluepyemodel/tools/utils.py
@@ -230,7 +230,7 @@ def select_rec_for_thumbnail(rec_names, additional_step_prots=None, thumbnail_re
         if "LocalInjection" not in rec_name and any(
             step_prot.lower() in rec_name.lower() for step_prot in step_prots
         ):
-            prot_name = rec_name.split(".")[0]
+            prot_name = ".".join(rec_name.split(".")[:-2])
             try:
                 _, rec_amp = format_protocol_name_to_list(prot_name)
                 if 0 < rec_amp < selected_amp:

--- a/tests/unit_tests/test_tools.py
+++ b/tests/unit_tests/test_tools.py
@@ -140,6 +140,15 @@ def test_select_rec_for_thumbnail():
         select_rec_for_thumbnail(rec_names, thumbnail_rec="sAHP_20.soma.v") == "IDrest_130.soma.v"
     )
 
+    # absolute amplitude with float amp case
+    rec_names = [
+        "IDrest_0.2.soma.v",
+        "IDrest_-0.04.soma.v",
+        "IDrest_0.13.soma.v",
+        "sAHP_0.04.soma.v",
+    ]
+    assert select_rec_for_thumbnail(rec_names) == "IDrest_0.13.soma.v"
+
 
 def test_get_protocol_name():
     # feature keys


### PR DESCRIPTION
We had to take into account that the amplitude might have a point in it, e.g. `0.2`.