### PR TITLE
Add simulated values to IV and FI plots for comparison with experimental data

### DIFF
--- a/bluepyemodel/emodel_pipeline/emodel_settings.py
+++ b/bluepyemodel/emodel_pipeline/emodel_settings.py
@@ -446,6 +446,14 @@ class EModelPipelineSettings:
         self.plot_IV_curves = plot_IV_curves
         self.plot_FI_curve_comparison = plot_FI_curve_comparison
         self.plot_traces_comparison = plot_traces_comparison
+        if extract_absolute_amplitudes is True:
+            if any((plot_IV_curves, plot_FI_curve_comparison)):
+                logger.warning(
+                    "The 'plot_IV_curves' and 'plot_FI_curve_comparison' features do not "
+                    "support absolute current amplitude. These plots have been disabled."
+                )
+                self.plot_IV_curves = False
+                self.plot_FI_curve_comparison = False
         if pickle_cells_extraction is False:
             if any((plot_IV_curves, plot_FI_curve_comparison, plot_traces_comparison)):
                 logger.warning(

--- a/bluepyemodel/emodel_pipeline/plotting.py
+++ b/bluepyemodel/emodel_pipeline/plotting.py
@@ -1236,11 +1236,10 @@ def plot_IV_curves(
         efel_settings = bluepyefe.tools.DEFAULT_EFEL_SETTINGS.copy()
 
     lower_bound = -100
-    upper_bound = 300
+    upper_bound = 100
 
     # Generate amplitude points
-    sim_amp_points = list(numpy.linspace(lower_bound, upper_bound, n_bin))
-
+    sim_amp_points = list(map(int, numpy.linspace(lower_bound, upper_bound, n_bin + 1)))
     # add missing features (if any) to evaluator
     updated_evaluator = fill_in_IV_curve_evaluator(
         evaluator, efel_settings, prot_name, sim_amp_points

--- a/bluepyemodel/emodel_pipeline/plotting.py
+++ b/bluepyemodel/emodel_pipeline/plotting.py
@@ -1538,7 +1538,7 @@ def plot_FI_curves_comparison(
         ax[1].plot(simulated_amp, simulated_freq, "o", color="blue", label="model")
         ax[1].set_xlabel("Amplitude (nA)")
         ax[1].set_ylabel("Voltage (mV)")
-        ax[1].set_title("IV curve (absolute amplitude)")
+        ax[1].set_title("FI curve (absolute amplitude)")
         ax[1].legend()
 
         if write_fig:

--- a/bluepyemodel/emodel_pipeline/plotting_utils.py
+++ b/bluepyemodel/emodel_pipeline/plotting_utils.py
@@ -265,7 +265,8 @@ def create_protocol(amp_rel, amp, feature, protocol, protocol_name):
     Arguments:
         amp_rel (float): Relative amplitude as a percentage of the threshold current.
         amp (float): Absolute amplitude to use for recalculating the stimulus amplitude.
-        feature (eFELFeatureBPEM, optional): Feature object used to retrieve the threshold current for scaling.
+        feature (eFELFeatureBPEM, optional): Feature object used to retrieve the threshold
+        current for scaling.
         protocol (BPEMProtocol): The original protocol to modify.
         protocol_name (str): Name for the new protocol.
 

--- a/bluepyemodel/emodel_pipeline/plotting_utils.py
+++ b/bluepyemodel/emodel_pipeline/plotting_utils.py
@@ -260,23 +260,17 @@ def find_matching_feature(evaluator, protocol_name):
 
 def create_protocol(amp_rel, amp, feature, protocol, protocol_name):
     """
-    Create a new threshold-based protocol with an adjusted stimulus amplitude.
+    Create a new protocol with adjusted stimulus amplitude based on a threshold.
 
-    This function generates a new protocol based on a given protocol,
-    adjusting the stimulus amplitude relative to a specified threshold.
-    If an absolute amplitude (`amp`) is provided,
-    the stimulus amplitude is recalculated based on the relative amplitude (`amp_rel`)
-    and the reference current from the feature.
-
-    Parameters:
-    - amp_rel: Relative amplitude as a percentage of the threshold current.
-    - amp: Absolute amplitude to use for recalculating the stimulus amplitude.
-    - feature: Optional feature object used to retrieve the threshold current for scaling.
-    - protocol: The original protocol to modify.
-    - protocol_name: Name for the new protocol.
+    Arguments:
+        amp_rel (float): Relative amplitude as a percentage of the threshold current.
+        amp (float): Absolute amplitude to use for recalculating the stimulus amplitude.
+        feature (eFELFeatureBPEM, optional): Feature object used to retrieve the threshold current for scaling.
+        protocol (BPEMProtocol): The original protocol to modify.
+        protocol_name (str): Name for the new protocol.
 
     Returns:
-    - A new protocol object with the adjusted threshold-based stimulus amplitude.
+        BPEMProtocol: A new protocol object with the adjusted threshold-based stimulus amplitude.
     """
     if amp is None:
         s_amp = amp_rel

--- a/bluepyemodel/emodel_pipeline/plotting_utils.py
+++ b/bluepyemodel/emodel_pipeline/plotting_utils.py
@@ -337,12 +337,15 @@ def fill_in_IV_curve_evaluator(evaluator, efel_settings, prot_name="iv", new_amp
                     prot_v_deflection.append(prot.name)
 
     if new_amps is not None:
+        prot_name_original = get_original_protocol_name(prot_name, evaluator)
         for amp in new_amps:
-            protocol_name_amp = f"{prot_name.split('_')[0]}_{amp}"
+            protocol_name_amp = f"{prot_name_original.split('_')[0]}_{amp}"
             if 0 <= amp < 100:
-                prot_max_v.append(protocol_name_amp)
+                if protocol_name_amp not in prot_max_v:
+                    prot_max_v.append(protocol_name_amp)
             elif amp < 0:
-                prot_v_deflection.append(protocol_name_amp)
+                if protocol_name_amp not in prot_v_deflection:
+                    prot_v_deflection.append(protocol_name_amp)
 
     # maps protocols of interest with all its associated features
     # also get protocol data we need for feature registration

--- a/examples/nexus/exploit_model.ipynb
+++ b/examples/nexus/exploit_model.ipynb
@@ -221,7 +221,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "evaluator.fitness_protocols[\"main_protocol\"].protocols[protocol_name] = my_protocol"
+    "evaluator.fitness_protocols[\"main_protocol\"].protocols[protocol_name] = my_protocol\n",
+    "evaluator.fitness_protocols[\"main_protocol\"].execution_order = (\n",
+    "    evaluator.fitness_protocols[\"main_protocol\"].compute_execution_order()\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
This PR enhances IV and FI plots by adding simulated data points at regular intervals for better comparison of experimental and simulated data. These plots are only generated for rheobase type optimisations, and a warning clarifies that they will not be plotted for non-rheobase cases.