### PR TITLE
Fix setting mismatch when doing absolute amplitude extraction

### DIFF
--- a/bluepyemodel/emodel_pipeline/emodel_settings.py
+++ b/bluepyemodel/emodel_pipeline/emodel_settings.py
@@ -408,6 +408,15 @@ class EModelPipelineSettings:
         # Specific to threshold based optimisation
         self.name_Rin_protocol = name_Rin_protocol
         self.name_rmp_protocol = name_rmp_protocol
+        if self.extract_absolute_amplitudes and (
+            self.name_Rin_protocol is not None or self.name_rmp_protocol is not None
+        ):
+            self.name_Rin_protocol = None
+            self.name_rmp_protocol = None
+            logger.warning(
+                "Setting threshold-based amplitude related settings "
+                "'name_rmp_protocol' and 'name_Rin_protocol' to None because "
+                "extract_absolute_amplitudes setting is set to True")
         self.strict_holding_bounds = strict_holding_bounds
 
         # Settings related to the validation

--- a/bluepyemodel/emodel_pipeline/emodel_settings.py
+++ b/bluepyemodel/emodel_pipeline/emodel_settings.py
@@ -416,7 +416,8 @@ class EModelPipelineSettings:
             logger.warning(
                 "Setting threshold-based amplitude related settings "
                 "'name_rmp_protocol' and 'name_Rin_protocol' to None because "
-                "extract_absolute_amplitudes setting is set to True")
+                "extract_absolute_amplitudes setting is set to True"
+            )
         self.strict_holding_bounds = strict_holding_bounds
 
         # Settings related to the validation


### PR DESCRIPTION
If name_rmp_protocol or name_Rin_protocol are set, then BPEM considers that we are doing threshold-based extraction, even if extract_absolute_amplitude is set. This PR should fix this.