### PR TITLE
store and re-use threshold current data

### DIFF
--- a/bluepyemodel/access_point/local.py
+++ b/bluepyemodel/access_point/local.py
@@ -666,6 +666,7 @@ class LocalAccessPoint(DataAccessPoint):
             passedValidation=model_data.get("validated", None),
             seed=model_data.get("seed", None),
             emodel_metadata=emodel_metadata,
+            threshold_data=model_data.get("threshold_data", None),
         )
 
         return emodel

--- a/bluepyemodel/emodel_pipeline/emodel.py
+++ b/bluepyemodel/emodel_pipeline/emodel.py
@@ -122,6 +122,7 @@ class EModel(EModelMixin):
         emodel_metadata=None,
         workflow_id=None,
         nexus_images=None,  # pylint: disable=unused-argument
+        threshold_data=None,
     ):
         """Init
 
@@ -138,6 +139,10 @@ class EModel(EModelMixin):
             workflow_id (str): EModelWorkflow id on nexus.
             nexus_images (list): list of pdfs associated to the emodel.
                 Not used, retained for legacy purposes only.
+            threshold_data (dict): contains rmp, Rin, holding current and threshold current values
+                to avoid re-computation of related protocols. Keys must match the 'output_key'
+                used in respective protocols. If None, threshold-related protocols will be
+                re-computed each time protocols are run.
         """
 
         self.emodel_metadata = emodel_metadata
@@ -175,6 +180,7 @@ class EModel(EModelMixin):
 
         self.responses = {}
         self.evaluator = None
+        self.threshold_data = threshold_data if threshold_data is not None else {}
 
     def copy_pdf_dependencies_to_new_path(self, seed, overwrite=False):
         """Copy pdf dependencies to new path using allen notation"""
@@ -212,4 +218,5 @@ class EModel(EModelMixin):
             "passedValidation": self.passed_validation,
             "nexus_images": pdf_dependencies,
             "seed": self.seed,
+            "threshold_data": self.threshold_data,
         }

--- a/bluepyemodel/evaluation/protocols.py
+++ b/bluepyemodel/evaluation/protocols.py
@@ -1002,7 +1002,7 @@ class ProtocolRunner(ephys.protocols.Protocol):
                 logger.debug(
                     "Skipping protocol %s, using saved value %s",
                     protocol_name,
-                    self.threshold_data[prot_output_key]
+                    self.threshold_data[prot_output_key],
                 )
                 new_responses = {prot_output_key, self.threshold_data[prot_output_key]}
             else:

--- a/bluepyemodel/evaluation/protocols.py
+++ b/bluepyemodel/evaluation/protocols.py
@@ -958,6 +958,7 @@ class ProtocolRunner(ephys.protocols.Protocol):
 
         self.protocols = protocols
         self.execution_order = self.compute_execution_order()
+        self.threshold_data = {}
 
     def _add_to_execution_order(self, protocol, execution_order, before_index=None):
         """Recursively adds protocols to the execution order while making sure that their
@@ -996,19 +997,28 @@ class ProtocolRunner(ephys.protocols.Protocol):
         cell_model.freeze(param_values)
 
         for protocol_name in self.execution_order:
-            logger.debug("Computing protocol %s", protocol_name)
-            new_responses = self.protocols[protocol_name].run(
-                cell_model,
-                param_values={},
-                sim=sim,
-                isolate=isolate,
-                timeout=timeout,
-                responses=responses,
-            )
+            prot_output_key = getattr(self.protocols[protocol_name], "output_key", None)
+            if prot_output_key in self.threshold_data:
+                logger.debug(
+                    "Skipping protocol %s, using saved value %s",
+                    protocol_name,
+                    self.threshold_data[prot_output_key]
+                )
+                new_responses = {prot_output_key, self.threshold_data[prot_output_key]}
+            else:
+                logger.debug("Computing protocol %s", protocol_name)
+                new_responses = self.protocols[protocol_name].run(
+                    cell_model,
+                    param_values={},
+                    sim=sim,
+                    isolate=isolate,
+                    timeout=timeout,
+                    responses=responses,
+                )
 
-            if new_responses is None or any(v is None for v in new_responses.values()):
-                logger.debug("None in responses, exiting evaluation")
-                break
+                if new_responses is None or any(v is None for v in new_responses.values()):
+                    logger.debug("None in responses, exiting evaluation")
+                    break
 
             responses.update(new_responses)
 

--- a/bluepyemodel/validation/validation.py
+++ b/bluepyemodel/validation/validation.py
@@ -130,6 +130,11 @@ def validate(access_point, mapper, preselect_for_validation=False):
             )
         )
 
+        # save threshold computation results
+        model.threshold_data = {
+            key: output for key, output in model.responses.items() if key[:4] == "bpo_"
+        }
+
         access_point.store_or_update_emodel(model)
 
     return emodels


### PR DESCRIPTION
Allows to skip threshold computation during analysis to save a little bit of CPU time.

- ability to store rmp, rin, holding current and threshold current in EModel object
- store them during validation
- ability to skip threshold computation if rmp, rin, holding current and threshold current are given to ProtocolRunner
- give rmp, rin, holding current and threshold current to ProtocolRunner during compute_responses()